### PR TITLE
Add a method to skip pinterest on certain elements

### DIFF
--- a/pinit_main.js
+++ b/pinit_main.js
@@ -1360,7 +1360,7 @@
               }
             }
           }
-          
+
           if ($.v.config.lang) {
             // a language has been specified in the call to pinit.js
             lang = $.v.config.lang;


### PR DESCRIPTION
My wife has a blog and this blog has 128x128 logo on top. She needs a way to make pinterest NOT attach "Pin It!" button to this particular image.

According to the code, there is no way to achieve such behavior, so I've added it.
