### PR TITLE
Add in data-pin-url

### DIFF
--- a/pinit_main.js
+++ b/pinit_main.js
@@ -289,7 +289,7 @@
             // get position, start href
             var p = $.f.getPos(img), href = $.v.endpoint.create;
             // set the button href
-            href = href + 'url=' + encodeURIComponent($.d.URL) + '&media=' + encodeURIComponent(img.src) + '&description=' + encodeURIComponent(img.getAttribute('data-pin-description') || img.title || img.alt || $.d.title);
+            href = href + 'url=' + encodeURIComponent(img.getAttribute('data-pin-url') || $.d.URL) + '&media=' + encodeURIComponent(img.src) + '&description=' + encodeURIComponent(img.getAttribute('data-pin-description') || img.title || img.alt || $.d.title);
 
             $.s.floatingButton = $.f.make({'A': {
               'className': buttonClass,


### PR DESCRIPTION
Give the user the ability to specify the url of the pin

I was running into a problem where the 'hover' version of PinIt.js was not linking to the permalink of the post. This commit puts the 'hover' version on parity with the hard coded version. (?url=)

refs https://github.com/pinterest/widgets/issues/8