### PR TITLE
Provide for hoverbuttons on src-less img elements with data-pin-media

### DIFF
--- a/pinit_main.js
+++ b/pinit_main.js
@@ -316,7 +316,7 @@
           var c = $.f.getButtonConfig(img);
 
           // size > 80x80 and source is not a data: uri?
-          if (img.height > $.a.minImgSize && img.width > $.a.minImgSize && !img.src.match(/^data/)) {
+          if (img.height > $.a.minImgSize && img.width > $.a.minImgSize && !($.f.getData(img, 'media') || img.src).match(/^data/)) {
 
             // make it fresh each time; this pays attention to individual image config options
             var buttonClass = $.a.k + '_pin_it_button_' + c.height + ' ' + $.a.k + '_pin_it_button_' + c.assets + '_' + c.height + '_' + c.color + ' ' + $.a.k + '_pin_it_button_floating_' + c.height;
@@ -366,7 +366,7 @@
           t = v || $.w.event;
           el = $.f.getEl(t);
           if (el) {
-            if (el.tagName === 'IMG' && el.src && !$.f.getData(el, 'no-hover') && !$.f.get(el, 'nopin') && !$.f.getData(el, 'nopin') && $.v.config.hover) {
+            if (el.tagName === 'IMG' && (el.src || $.f.getData(el, 'media')) && !$.f.getData(el, 'no-hover') && !$.f.get(el, 'nopin') && !$.f.getData(el, 'nopin') && $.v.config.hover) {
               // we are inside an image
               if ($.v.hazFloatingButton === false) {
                 // show the floating button

--- a/pinit_main.js
+++ b/pinit_main.js
@@ -783,7 +783,7 @@
           el = $.f.getEl(t);
           if (el) {
             src = $.f.getData(el, 'media') || el.src;
-            if (el.tagName === 'IMG' && src && !src.match(/^data/) && !$.f.getData(el, 'no-hover') && !$.f.get(el, 'nopin') && !$.f.getData(el, 'nopin') && $.v.config.hover) {
+            if (el.tagName === 'IMG' && src && !src.match(/^data/) && !$.f.getData(el, 'no-hover') && !$.f.get(el, 'nopin') && !$.f.getData(el, 'nopin')) {
               // we are inside an image
               if (!$.v.hazHoverButton) {
                 // show the hoverbutton


### PR DESCRIPTION
Pinit.js currently shows hoverbuttons only when the image contains a nonempty src attribute. Made lots of sense in HTML4. In HTML5, to support fetching of appropriately sized image assets for multiple screen sizes, the specification allows for img elements that happily load pictures without an src attribute in sight, either by use of srcset or a parent picture element. Some generators (Wordpress 4.4 for example) are leaving an src attribute in place, thus not breaking pinit.js, but others (Drupal 8 with responsive images enabled for example) have removed src from their markup entirely and added the picturefill shim in order to support responsive image retrieval in legacy browsers as well. This is the only pattern that gives responsive image retrieval capabilities to both modern and legacy browsers, so it is likely to be seen more and more often, but since no src attribute is present it is not compatible with pinit.js.

This pull request, in action @ https://www.tangledupinfood.com/, is the least disruptive solution I came up with after some hours of head scratching. It would be nice to have pinit.js identify the "best" image from these sets for pinning, and thus work out-of-the-box on srcset+picturefill sites, but given the complexity of the picture element and experimental status of DOM interfaces when they are available at all, this level of support doesn't seem very feasible. However, if we require sites using the picturefill pattern to add data-pin-media to their pinnable responsive images, then only these two lines seem to need any changing. It at least gives them a path to having hoverbuttons.