### PR TITLE
Meta Tag Configuration Option

### DIFF
--- a/pinit_main.js
+++ b/pinit_main.js
@@ -1438,6 +1438,25 @@
             }
           }
 
+          // find and apply configuration requests passed as META tags
+          var metas = $.d.getElementsByTagName('META'), i, j;
+
+          // loop through all META tags
+          for (i = metas.length - 1; i > -1; i = i - 1) {
+
+            // is it us?
+            if (metas[i] && metas[i].hasAttribute("property") && metas[i].hasAttribute("content")) {
+              // loop through all possible config params
+              for (j = 0; j < $.a.configParam.length; j = j + 1) {
+                if (metas[i].getAttribute("property") ==  $.a.dataAttributePrefix + $.a.configParam[j]) {
+                  // set or overwrite config param with contents
+                  $.v.config[$.a.configParam[j]] = metas[i].content;
+                  // burn after reading to prevent future calls from re-reading config params
+                  $.f.kill(metas[i]);
+               }
+              }
+            }
+          }
           if (typeof $.v.config.build === 'string') {
             $.w[$.v.config.build] = function (el) {
               $.f.build(el);


### PR DESCRIPTION
Code has been added to cycle through the meta tags of the page looking for configuration options that can otherwise be set on the calling script tag. In particular, this allows the data-pin-hover option to be set even when a script tag isn't present such as when an asynchronous JavaScript loader is being used.

Once the change has been made the following meta tag will result in the same effect as using `<script src="pinit.js" data-pin-hover="true">`.

`<meta property="data-pin-hover" content="true">`
