### PR TITLE
Arbitrary button node structure (deeper than 1 level)

### DIFF
--- a/pinit_main.js
+++ b/pinit_main.js
@@ -884,8 +884,8 @@
           el = $.f.getEl(v);
           if (el) {
             log = $.f.getData(el, "log");
-            // custom buttons with child nodes may not pass clicks; check one level up
-            if (!log && el.parentNode) {
+            // custom buttons with child nodes may not pass clicks; check the parents
+            while (!log && el.parentNode) {
               el = el.parentNode;
               log = $.f.getData(el, "log");
             }


### PR DESCRIPTION
Simple change to enable share buttons with a structure deeper than 1 level currently supported. My use case is:

```
<a data-pin-do="buttonBookmark" data-pin-custom="true" ..>
  <div ..>
    <svg ..>
      ..
    </svg>
  </div>
</a>
```
In this case, click events go to the node and the stock Pinterest code does not work as expected.